### PR TITLE
add hotkey for split preview refresh

### DIFF
--- a/src/neuroglancer/segmentation_user_layer_with_graph.ts
+++ b/src/neuroglancer/segmentation_user_layer_with_graph.ts
@@ -31,7 +31,7 @@ import {StatusMessage} from 'neuroglancer/status';
 import {trackableAlphaValue} from 'neuroglancer/trackable_alpha';
 import {TrackableBoolean} from 'neuroglancer/trackable_boolean';
 import {TrackableValue, WatchableRefCounted, WatchableValue} from 'neuroglancer/trackable_value';
-import {enableSplitPointTool, GraphOperationTab, PlaceGraphOperationMarkerTool, SelectedGraphOperationState} from 'neuroglancer/ui/graph_multicut';
+import {enableSplitPointTool, GraphOperationTab, PlaceGraphOperationMarkerTool, SelectedGraphOperationState, SplitPreview} from 'neuroglancer/ui/graph_multicut';
 import {Uint64Set} from 'neuroglancer/uint64_set';
 import {TrackableRGB} from 'neuroglancer/util/color';
 import {Borrowed, RefCounted} from 'neuroglancer/util/disposable';
@@ -326,6 +326,15 @@ function helper<TBase extends BaseConstructor>(Base: TBase) {
         }
         case 'refresh-all-meshes': {
           this.reloadAllManifests();
+          break;
+        }
+        case 'refresh-split-preview': {
+          StatusMessage.showTemporaryMessage(`Refreshing split preview...`);
+          let Preview = new SplitPreview(this, this.graphOperationLayerState.value!);
+          if (Preview.inPreviewMode) {
+            Preview.disablePreview()
+          };
+          Preview.button.click();
           break;
         }
         case 'switch-multicut-group': {

--- a/src/neuroglancer/ui/default_input_event_bindings.ts
+++ b/src/neuroglancer/ui/default_input_event_bindings.ts
@@ -51,6 +51,7 @@ export function getDefaultGlobalBindings() {
     map.set('keyp', 'refresh-all-meshes');
     map.set('keyi', 'increase-segmentation-opacity');
     map.set('keyx', 'dismiss-all-status-messages');
+    map.set('keyq', 'refresh-split-preview');
     defaultGlobalBindings = map;
   }
   return defaultGlobalBindings;

--- a/src/neuroglancer/ui/graph_multicut.ts
+++ b/src/neuroglancer/ui/graph_multicut.ts
@@ -684,9 +684,9 @@ export class GraphOperationLayerView extends Tab {
 /**
  * Wrapper class for split preview UI logic
  */
-class SplitPreview extends RefCounted {
+ export class SplitPreview extends RefCounted {
   button: HTMLButtonElement;
-  private inPreviewMode = false;
+  public inPreviewMode = false;
   private splitPreviewRenderLayers: SupervoxelRenderLayer[] = [];
   private cachedPreviewConnectedComponents: Uint64Set[] = [];
   private removeStatusMessages: (() => void)|undefined;
@@ -809,6 +809,7 @@ class SplitPreview extends RefCounted {
 
   public disablePreview =
       () => {
+        console.log('disabling Preview MEME')
         this.inPreviewMode = false;
         this.revertPreviewButton();
         // Remove preview render layers
@@ -825,6 +826,7 @@ class SplitPreview extends RefCounted {
       }
 
   private revertPreviewButton = () => {
+    console.log('REVERT PREVIEW BUTTON')
     const {button} = this;
     button.title = 'Split preview';
     button.style.borderStyle = '';

--- a/src/neuroglancer/viewer.ts
+++ b/src/neuroglancer/viewer.ts
@@ -763,7 +763,8 @@ export class Viewer extends RefCounted implements ViewerState {
     for (const action
              of ['recolor', 'clear-segments', 'merge-selected', 'cut-selected',
                  'shatter-segment-equivalences', 'switch-multicut-group', 
-                 'decrease-segmentation-opacity', 'increase-segmentation-opacity', 'refresh-all-meshes']) {
+                 'decrease-segmentation-opacity', 'increase-segmentation-opacity',
+                 'refresh-all-meshes', 'refresh-split-preview']) {
       this.bindAction(action, () => {
         this.layerManager.invokeAction(action);
       });


### PR DESCRIPTION
logic for refreshing the split preview is in `src/neuroglancer/segmentation_user_layer_with_graph.ts`
Bugs:
    - calling `SplitPreview.disablePreview()` as is does not remove the previous split preview as expected
